### PR TITLE
Replace environment variables in config files

### DIFF
--- a/lib/envvar-replace.js
+++ b/lib/envvar-replace.js
@@ -1,0 +1,12 @@
+module.exports = function(str, vars) {
+
+	return str.replace(/\$\{([A-Za-z0-9]+)(:-(.*?))?\}/g, function(varStr, varName, _, defValue) {
+		if (vars.hasOwnProperty(varName)) {
+			return vars[varName];
+		}
+		if (defValue) {
+			return defValue;
+		}
+		throw new Error('Unknown variable: ' + parts[1]);
+	});
+};

--- a/lib/envvar-replace.js
+++ b/lib/envvar-replace.js
@@ -1,6 +1,6 @@
 module.exports = function(str, vars) {
 
-	return str.replace(/\$?\$\{([A-Za-z0-9]+)(:-(.*?))?\}/g, function(varStr, varName, _, defValue) {
+	return str.replace(/\$?\$\{([A-Za-z0-9_]+)(:-(.*?))?\}/g, function(varStr, varName, _, defValue) {
 		// Handle escaping:
 		if (varStr.indexOf('$$') === 0) {
 			return varStr;

--- a/lib/envvar-replace.js
+++ b/lib/envvar-replace.js
@@ -1,12 +1,18 @@
 module.exports = function(str, vars) {
 
-	return str.replace(/\$\{([A-Za-z0-9]+)(:-(.*?))?\}/g, function(varStr, varName, _, defValue) {
+	return str.replace(/\$?\$\{([A-Za-z0-9]+)(:-(.*?))?\}/g, function(varStr, varName, _, defValue) {
+		// Handle escaping:
+		if (varStr.indexOf('$$') === 0) {
+			return varStr;
+		}
+		// Handle simple variable replacement:
 		if (vars.hasOwnProperty(varName)) {
 			return vars[varName];
 		}
+		// Handle default values:
 		if (defValue) {
 			return defValue;
 		}
-		throw new Error('Unknown variable: ' + parts[1]);
+		throw new Error('Unknown variable: ' + varName);
 	});
 };

--- a/lib/optimist-config-file.js
+++ b/lib/optimist-config-file.js
@@ -31,12 +31,12 @@ function parseConfigFile(configFileName, replacementVars) {
 	// parse it
 	try {
 		raw = fs.readFileSync(configFileName).toString();
-		if (replacementVars instanceof Object) {
-			raw = replace(raw, replacementVars);
-		}
 
 		switch (configMode) {
 			case 'YAML':
+				if (replacementVars instanceof Object) {
+					raw = replace(raw, replacementVars);
+				}
 				configParsed = yaml.safeLoad(raw);
 				break;
 

--- a/lib/optimist-config-file.js
+++ b/lib/optimist-config-file.js
@@ -10,9 +10,10 @@ var debug = require('debug')('optimist:config'),
 	fs = require('fs'),
 	optimist = require('optimist')(process.argv.slice(2)),
 	ansistyles = require('ansistyles'),
-	yaml = require('js-yaml');
+	yaml = require('js-yaml'),
+	replace = require('./envvar-replace');
 
-function parseConfigFile(configFileName) {
+function parseConfigFile(configFileName, replacementVars) {
 	var raw,
 		configMode,
 		configParsed;
@@ -30,6 +31,9 @@ function parseConfigFile(configFileName) {
 	// parse it
 	try {
 		raw = fs.readFileSync(configFileName).toString();
+		if (replacementVars instanceof Object) {
+			raw = replace(raw, replacementVars);
+		}
 
 		switch (configMode) {
 			case 'YAML':
@@ -85,7 +89,7 @@ optimist.parse = function(args) {
 		return options;
 	}
 
-	configParsed = parseConfigFile(configFileName);
+	configParsed = parseConfigFile(configFileName, this.replacementVars);
 
 	// apply the rest of the options provided via command line
 	Object.keys(configParsed).forEach(function(key) {
@@ -107,6 +111,11 @@ optimist.parse = function(args) {
 
 optimist.setConfigFile = function(configFileParam) {
 	this.configFileParam = configFileParam;
+	return this;
+};
+
+optimist.setReplacementVars = function(replacementVars) {
+	this.replacementVars = replacementVars;
 	return this;
 };
 

--- a/test/envvar-replace-test.js
+++ b/test/envvar-replace-test.js
@@ -39,6 +39,12 @@ vows.describe('module').addBatch({
 			assert.equal(err.message, 'Unknown variable: MYVAR');
 		}
 	},
+	'when called with an escaped environment variable': {
+		topic: replace('foo: $${MYVAR}', {}),
+		'the variable should not be replaced': function(err, replaced) {
+			assert.equal(replaced, 'foo: $${MYVAR}');
+		}
+	},
 	'when called with a string containing a variable with a default value': {
 		topic: replace('foo: ${MYVAR:-baz}', {}),
 		'the default value should be used': function(err, replaced) {

--- a/test/envvar-replace-test.js
+++ b/test/envvar-replace-test.js
@@ -1,0 +1,54 @@
+var vows = require('vows'),
+	assert = require('assert'),
+	path = require('path'),
+	replace = require('../lib/envvar-replace');
+
+vows.describe('module').addBatch({
+	'when called with a string with no variables': {
+		topic: replace('foo', {}),
+		'we get back the original string': function(err, replaced) {
+			assert.equal('foo', replaced);
+		}
+	},
+	'when called with a string with a variable': {
+		topic: replace('foo: ${MYVAR}', {
+			MYVAR: 'bar'
+		}),
+		'the variable should be replaced': function(err, replaced) {
+			assert.equal(replaced, 'foo: bar');
+		}
+	},
+	'when called with a string with multiple variables': {
+		topic: replace('foo: ${MYVAR} baz: ${MYOTHERVAR}', {
+			MYVAR: 'bar',
+			MYOTHERVAR: 'boo',
+		}),
+		'all variables should be replaced': function(err, replaced) {
+			assert.equal(replaced, 'foo: bar baz: boo');
+		}
+	},
+	'when called with a string containing variables we do not have': {
+		topic: function() {
+			try {
+				this.callback(null, replace('foo: ${MYVAR}', {}));
+			} catch (err) {
+				this.callback(err);
+			}
+		},
+		'an error should be thrown': function(err, replaced) {
+			assert.equal(err.message, 'Unknown variable: MYVAR');
+		}
+	},
+	'when called with a string containing a variable with a default value': {
+		topic: replace('foo: ${MYVAR:-baz}', {}),
+		'the default value should be used': function(err, replaced) {
+			assert.equal(replaced, 'foo: baz');
+		}
+	},
+	'when called with a string containing a variable with a complex default value': {
+		topic: replace('foo: ${MYVAR:-http://google.com}', {}),
+		'the default value should be used': function(err, replaced) {
+			assert.equal(replaced, 'foo: http://google.com');
+		}
+	}
+}).export(module);

--- a/test/envvar-replace-test.js
+++ b/test/envvar-replace-test.js
@@ -50,7 +50,7 @@ vows.describe('module').addBatch({
 			MY_VAR: 'bar'
 		}),
 		'the variable should be replaced': function(err, replaced) {
-			assert.equal(replaced, 'foo: bar')
+			assert.equal(replaced, 'foo: bar');
 		}
 	},
 	'when called with a string containing a variable with a default value': {

--- a/test/envvar-replace-test.js
+++ b/test/envvar-replace-test.js
@@ -39,10 +39,18 @@ vows.describe('module').addBatch({
 			assert.equal(err.message, 'Unknown variable: MYVAR');
 		}
 	},
-	'when called with an escaped environment variable': {
+	'when called with an escaped variable': {
 		topic: replace('foo: $${MYVAR}', {}),
 		'the variable should not be replaced': function(err, replaced) {
 			assert.equal(replaced, 'foo: $${MYVAR}');
+		}
+	},
+	'when called with an a variable containing an underscore': {
+		topic: replace('foo: ${MY_VAR}', {
+			MY_VAR: 'bar'
+		}),
+		'the variable should be replaced': function(err, replaced) {
+			assert.equal(replaced, 'foo: bar')
 		}
 	},
 	'when called with a string containing a variable with a default value': {

--- a/test/fixtures/envvars.json
+++ b/test/fixtures/envvars.json
@@ -1,0 +1,3 @@
+{
+  "simple": "${SIMPLE}"
+}

--- a/test/fixtures/envvars.yaml
+++ b/test/fixtures/envvars.yaml
@@ -1,0 +1,2 @@
+simple: ${SIMPLE}/bar
+default: ${DEFAULT:-baz}/bar

--- a/test/parsing-test.js
+++ b/test/parsing-test.js
@@ -71,7 +71,7 @@ vows.describe('config file parsing').addBatch({
 			assert.ok(err.indexOf('JSON config file parsing failed (SyntaxError: Unexpected token') === 0);
 		}
 	},
-	'should interpolate environment variables': {
+	'should interpolate environment variables in YAML': {
 		topic: importFile(path.join(fixtures, 'envvars.yaml'), null, {
 			SIMPLE: 'foo'
 		}),
@@ -80,6 +80,14 @@ vows.describe('config file parsing').addBatch({
 		},
 		'should allow a default value for a variable': function(err, options) {
 			assert.equal(options.default, 'baz/bar');
+		}
+	},
+	'should not interpolate environment variables in JSON': {
+		topic: importFile(path.join(fixtures, 'envvars.json'), null, {
+			SIMPLE: 'foo'
+		}),
+		'should not replace the variable': function(err, options) {
+			assert.equal(options.simple, '${SIMPLE}');
 		}
 	}
 }).export(module);

--- a/test/parsing-test.js
+++ b/test/parsing-test.js
@@ -3,11 +3,12 @@ var vows = require('vows'),
 	path = require('path'),
 	program = require('../');
 
-function importFile(filename, argv) {
+function importFile(filename, argv, replacements) {
 	argv = argv || [];
 	argv.push('--config=' + filename);
 	var app = program;
 	app.setConfigFile('config');
+	app.setReplacementVars(replacements);
 	return app.parse(argv);
 }
 
@@ -68,6 +69,17 @@ vows.describe('config file parsing').addBatch({
 		},
 		'should throw an error': function(err, options) {
 			assert.ok(err.indexOf('JSON config file parsing failed (SyntaxError: Unexpected token') === 0);
+		}
+	},
+	'should interpolate environment variables': {
+		topic: importFile(path.join(fixtures, 'envvars.yaml'), null, {
+			SIMPLE: 'foo'
+		}),
+		'should replace a simple variable': function(err, options) {
+			assert.equal(options.simple, 'foo/bar');
+		},
+		'should allow a default value for a variable': function(err, options) {
+			assert.equal(options.default, 'baz/bar');
 		}
 	}
 }).export(module);


### PR DESCRIPTION
Here's a shot at replacing the environment variables.  The would be an opt-in feature that you'd have to enable by calling `program.setReplacementVars(process.env)`.  I'm pretty sure there are some weird edge cases I haven't covered here, but this gets the basic replacement out of the way, as well as allowing defaults for any environment variable using the same syntax Docker Compose uses.  So this works:

```yaml
# Assuming BASE_URL=http://google.com
url: ${BASE_URL} # url: http://google.com
url: ${NONEXISTENT_VAR:-http://bing.com} # url: http://bing.com
```
but this will throw an error:
```yaml
url: ${NONEXISTENT_VAR}
```
