### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "homepage": "https://github.com/macbre/optimist-config-file#readme",
   "dependencies": {
     "ansistyles": "^0.1.3",
-    "debug": "^2.6.0",
-    "js-yaml": "^3.7.0",
+    "debug": "^2.6.8",
+    "js-yaml": "^3.8.4",
     "optimist": "^0.6.1"
   },
   "devDependencies": {
-    "js-beautify": "^1.6.8",
+    "js-beautify": "^1.6.14",
     "jshint": "^2.9.4",
-    "vows": "^0.7.0"
+    "vows": "^0.8.1"
   },
   "scripts": {
     "test": "vows --spec",


### PR DESCRIPTION
✗ Low severity vulnerability found on ms@0.7.2
- desc: Regular Expression Denial of Service (ReDoS)
- info: https://snyk.io/vuln/npm:ms:20170412
- from: `phantomas@1.18.0 > optimist-config-file@1.0.0 > debug@2.6.0 > ms@0.7.2`
Your dependencies are out of date, otherwise you would be using a newer ms than `ms@0.7.2.`
Try deleting node_modules, reinstalling and running `snyk test` again.
If the problem persists, one of your dependencies may be bundling outdated modules.